### PR TITLE
Solved Mono Touch Exception

### DIFF
--- a/PrismExample/App.xaml.cs
+++ b/PrismExample/App.xaml.cs
@@ -23,7 +23,7 @@ namespace PrismExample
             InitializeComponent();
 
             //#82
-            NavigationService.NavigateAsync("NavigationPage/BooksPage");
+            NavigationService.NavigateAsync("NavigationPage/BookPage");
         }
 
         protected override void RegisterTypes(IContainerRegistry containerRegistry)


### PR DESCRIPTION
It seems there was a small typo, your Page is called `BookPage` and you had written `BooksPage` when setting the navigation.